### PR TITLE
fix(starship): set ARCH dynamically from uname -m

### DIFF
--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -214,6 +214,8 @@ in
           # Word split characters
           export WORDCHARS='*?[]~&;!#$%^(){}<>'
 
+          export ARCH=$(uname -m)
+
           # Source custom zsh configs
           for config_file in $XDG_CONFIG_HOME/zsh/*.zsh(N); do
             source "$config_file"
@@ -540,7 +542,6 @@ in
 
         env_var.ARCH = {
           variable = "ARCH";
-          default = "x86_64";
           style = "lantern";
         };
 


### PR DESCRIPTION
## Summary

- `env_var.ARCH` モジュールに `default = "x86_64"` がハードコードされており、`ARCH` 環境変数が未設定のため Apple Silicon Mac でも常に `x86_64` が表示されていた
- `programs.zsh.initContent` に `export ARCH=$(uname -m)` を追加し、シェル起動時に実際のアーキテクチャを動的にセット
- 誤解を招く `default = "x86_64"` を削除

## Test plan

- [ ] `make switch` で設定を適用
- [ ] 新しいシェルを開いて `echo $ARCH` → `arm64` が表示されること
- [ ] `x64` エイリアスで起動した Rosetta シェルで `echo $ARCH` → `x86_64` が表示されること
- [ ] starship プロンプトの `with x86_64` が `with arm64` に変わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)