### PR TITLE
feat: add ccstatusline as home-manager package

### DIFF
--- a/config/ccstatusline/settings.json
+++ b/config/ccstatusline/settings.json
@@ -1,0 +1,38 @@
+{
+  "version": 3,
+  "displayLines": [
+    {
+      "widgets": ["Model", "GitBranch", "GitChanges", "GitWorktree"]
+    },
+    {
+      "widgets": [
+        "ContextBar",
+        "ContextLength",
+        "ContextPercentage",
+        "SessionCost",
+        "WeeklyUsage"
+      ]
+    }
+  ],
+  "powerline": {
+    "enabled": true,
+    "separators": [""],
+    "separatorInvertBackground": [true],
+    "startCaps": [""],
+    "endCaps": [""],
+    "theme": null,
+    "autoAlign": false,
+    "continueThemeAcrossLines": false
+  },
+  "flexMode": "full-minus-40",
+  "compactThreshold": 60,
+  "colorLevel": 3,
+  "gitCacheTtl": 5,
+  "updateMessaging": {
+    "enabled": false
+  },
+  "installationMetadata": {
+    "type": "self-managed",
+    "packageManager": "npm"
+  }
+}

--- a/lib/mkdarwin.nix
+++ b/lib/mkdarwin.nix
@@ -33,6 +33,31 @@ let
   # gh-ghq-cd ships its own flake exposing a `gh-ghq-cd` package.
   gh-ghq-cd-pkg = inputs.gh-ghq-cd.packages.${system}.gh-ghq-cd;
 
+  # ccstatusline — Claude Code status line formatter, fetched from npm registry.
+  # The npm tarball ships a pre-built Bun bundle at dist/ccstatusline.js.
+  # To update: bump version, re-run nix-prefetch-url, update hash.
+  ccstatusline-pkg = pkgs.stdenvNoCC.mkDerivation rec {
+    pname = "ccstatusline";
+    version = "2.2.19";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/ccstatusline/-/ccstatusline-${version}.tgz";
+      hash = "sha256-ZECyfJStzolhs1EQrrbq6svXCtvcpj6YJRPjFIazLSw=";
+    };
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    dontConfigure = true;
+    dontBuild = true;
+    unpackPhase = ''
+      tar xzf $src
+      cd package
+    '';
+    installPhase = ''
+      mkdir -p $out/lib/ccstatusline $out/bin
+      cp -r . $out/lib/ccstatusline/
+      makeWrapper ${pkgs.nodejs}/bin/node $out/bin/ccstatusline \
+        --add-flags "$out/lib/ccstatusline/dist/ccstatusline.js"
+    '';
+  };
+
   specialArgs = {
     inherit inputs tpm;
     configName = name;
@@ -55,7 +80,7 @@ nix-darwin.lib.darwinSystem {
         useUserPackages = true;
         backupFileExtension = "backup";
         extraSpecialArgs = specialArgs // {
-          inherit gh-branch-pkg gh-ghq-cd-pkg;
+          inherit gh-branch-pkg gh-ghq-cd-pkg ccstatusline-pkg;
         };
         users.${user} = {
           imports = [

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -7,6 +7,7 @@
   dotfilesRoot,
   gh-branch-pkg,
   gh-ghq-cd-pkg,
+  ccstatusline-pkg,
   ...
 }:
 let
@@ -107,6 +108,9 @@ in
       # Media processing
       imagemagick
       ffmpeg
+
+      # Claude Code
+      ccstatusline-pkg
     ];
 
     # Session variables
@@ -145,6 +149,7 @@ in
   # XDG config file symlinks
   xdg.configFile = {
     "nvim".source = mutableConfigSource "nvim";
+    "ccstatusline".source = mutableConfigSource "ccstatusline";
     "karabiner/karabiner.json".source = mutableConfigSource "karabiner/karabiner.json";
     "zsh/10_utils.zsh".source = mutableConfigSource "zsh/10_utils.zsh";
     "zsh/20_keybinds.zsh".source = mutableConfigSource "zsh/20_keybinds.zsh";


### PR DESCRIPTION
## Summary

- `ccstatusline`（Claude Code ステータスライン）を npm registry tarball から Nix derivation としてパッケージング
- `home.packages` に追加し `make switch` で常にインストールされるように管理
- `config/ccstatusline/settings.json` を `mutableConfigSource` パターンで dotfiles 管理（`~/.config/ccstatusline/` へ out-of-store symlink）

## 表示内容

- Line 1: Model, GitBranch, GitChanges, GitWorktree
- Line 2: ContextBar, ContextLength, ContextPercentage, SessionCost, WeeklyUsage
- Powerline: 有効

## 反映手順

1. `make switch` でインストール
2. `~/.claude/settings.json` に手動追加:
   ```json
   {
     "statusLine": {
       "type": "command",
       "command": "ccstatusline"
     }
   }
   ```

## バージョン更新

`lib/mkdarwin.nix` の `version` と `hash` を更新後に `make switch`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)