### PR TITLE
feat(macmini): declare power settings via nix-darwin

### DIFF
--- a/hosts/sh05MacminiM2/default.nix
+++ b/hosts/sh05MacminiM2/default.nix
@@ -13,6 +13,16 @@
     "Xcode" = 497799835;
   };
 
+  # 電源設定（常時稼働のMac mini向け。MacBookには適用しない）
+  power = {
+    sleep = {
+      computer = "never"; # 自動スリープしない
+      display = 10; # ディスプレイは10分でオフ
+      harddisk = 10; # ディスクは10分でスリープ
+    };
+    restartAfterPowerFailure = true; # 停電後に自動再起動
+  };
+
   # Enable SSH (optional, can be disabled if not needed)
   # services.openssh.enable = true;
 }


### PR DESCRIPTION
## 概要

Mac mini (`sh05MacminiM2`) でGUIから設定していた電源設定を nix-darwin の型付きオプションで宣言的に管理する。

## 変更内容

`hosts/sh05MacminiM2/default.nix` に以下を追加:

- `power.sleep.computer = "never"` — 自動スリープしない（現在の `pmset` 実機値 `sleep 0` を反映）
- `power.sleep.display = 10` — ディスプレイは10分でオフ
- `power.sleep.harddisk = 10` — ディスクは10分でスリープ
- `power.restartAfterPowerFailure = true` — 停電後に自動再起動

常時稼働のMac mini専用の設定のためホスト固有ファイルに配置し、work MacBook Proには適用されない。`lowpowermode` / `powernap` 等のnix-darwinに型付きオプションがないpmset項目は対象外（GUI管理のまま）。

## 検証

- `nix flake check` ✅
- `nix build .#darwinConfigurations.sh05MacminiM2.system` ✅
- 生成された `result/activate` に `systemsetup -setComputerSleep 'never'` / `-setDisplaySleep '10'` / `-setHardDiskSleep '10'` / `-setRestartPowerFailure 'on'` が含まれることを確認 ✅

merge後、Mac mini側で `make switch` → `pmset -g custom` で値が維持されることを確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)