### PR TITLE
fix(home): make mutableConfigSource actually create out-of-store symlinks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ To add a new tool's config: drop files into `config/<tool>/` and add an entry us
 xdg.configFile."<tool>".source = mutableConfigSource "<tool>";
 ```
 
-The helper falls back to the Nix store path when the repo checkout isn't present (e.g. in CI).
+The helper must NOT gate on `builtins.pathExists` (or otherwise read the checkout path at eval time): `darwin-rebuild switch --flake` evaluates in pure mode, where store-external absolute paths are unreadable, so such a check silently falls back for every tool and pins configs to a read-only store copy. `mkOutOfStoreSymlink` doesn't validate its target at build time, so evaluation also succeeds where the checkout is absent (e.g. CI) — the link is simply dangling there.
 
 `config/nvim/` is a full LazyVim setup managed by lazy.nvim — Nix only installs the `neovim` binary and LSP servers; plugins are managed inside Neovim. Ghostty and gh-dash used to live in `config/` as raw files but are now configured declaratively via `programs.ghostty.settings` / `programs.gh-dash.settings` so the akari module can layer its theme settings on top.
 

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -11,15 +11,12 @@
   ...
 }:
 let
-  mutableConfigSource =
-    path:
-    let
-      outOfStorePath = "${dotfilesRoot}/config/${path}";
-    in
-    if builtins.pathExists outOfStorePath then
-      config.lib.file.mkOutOfStoreSymlink outOfStorePath
-    else
-      "${../../config}/${path}";
+  # NOTE: no pathExists fallback — pure eval (darwin-rebuild switch --flake)
+  # cannot read paths outside the store, so the check always returned false
+  # and silently pinned every config to a read-only store copy.
+  # mkOutOfStoreSymlink never validates its target at build time, so this
+  # also evaluates fine in CI where the checkout path doesn't exist.
+  mutableConfigSource = path: config.lib.file.mkOutOfStoreSymlink "${dotfilesRoot}/config/${path}";
 in
 {
   home = {
@@ -691,6 +688,12 @@ in
       defaultEditor = true;
       viAlias = true;
       vimAlias = true;
+      # home-manager auto-generates an init.lua (provider toggles), which
+      # collides with the whole-directory config/nvim symlink. Sideload it
+      # via wrapper args so the repo's init.lua stays the only one.
+      sideloadInitLua = true;
+      withPython3 = false;
+      withRuby = false;
     };
   };
 }


### PR DESCRIPTION
## 問題

ccstatusline の設定保存が `EACCES: permission denied, open '~/.config/ccstatusline/settings.json.*.tmp'` で失敗する。

## 原因

`darwin-rebuild switch --flake` は **pure 評価**で実行され、pure 評価では `builtins.pathExists` がストア外の絶対パスに対して常に `false` を返す(実測: pure=`false` / `--impure`=`true`)。そのため `mutableConfigSource` の `pathExists` ガードは常にフォールバック側を選び、`config/` 全体がストアにコピーされて read-only になっていた。**out-of-store symlink は一度も機能していなかった。**

影響: `ccstatusline`(EACCES)、`nvim`(lazy.nvim が lazy-lock.json を書けない)、`karabiner.json`(GUI 変更が保存不能)、`zsh/*.zsh`(symlink 越し編集が不成立)。

## 修正

- `pathExists` ガードを削除し、無条件で `mkOutOfStoreSymlink` を使用。ビルド時にリンク先を検証しないため、チェックアウトが無い CI でも評価・ビルドは通る(リンクがダングリングになるだけ)。
- 修正で顕在化した潜在バグも解消: `programs.neovim` が自動生成する `nvim/init.lua`(プロバイダ無効化のみ)が、ディレクトリ全体の `config/nvim` リンクと衝突(従来はストアコピーに対して黙って捨てられていた)。`sideloadInitLua = true` でラッパー引数経由の読み込みに変更し、未使用の python3/ruby プロバイダも無効化。
- CLAUDE.md の該当記述を実態に合わせて更新。

## 検証

- [x] `nix build .#darwinConfigurations.sh05MacminiM2.system` が pure 評価で成功
- [x] `nix flake check` 成功(CI 相当)
- [x] ビルド成果物の `.config/ccstatusline` / `.config/nvim` が `/Users/sh05/ghq/github.com/sh05/dotfiles/config/…` を指すことを確認

## マージ後の手順(要ユーザー操作)

1. `make switch`(sudo が必要)
2. `readlink -f ~/.config/ccstatusline` がリポジトリを指すことを確認
3. ccstatusline の設定 UI で保存 → `git diff config/ccstatusline/` に変更が現れること
4. 補足: `~/.config/ccstatusline.backup`(5/23 の旧設定)が repo の settings.json に移行済みか diff 確認を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)