### PR TITLE
feat: migrate from tmux to herdr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,10 @@ When adding a new host, create `hosts/<name>/default.nix` and add a `mkDarwin` e
 ### Module layout
 
 - `nix/darwin/default.nix` — macOS `system.defaults` (Dock/Finder/trackpad/Rectangle plist), Homebrew `casks`/`brews`/`masApps` shared across hosts, system fonts.
-- `nix/home/default.nix` — home-manager: `home.packages` (CLI/LSP/languages), `programs.*` declarative tool config (zsh, git, tmux, starship, delta, gh, bat, lazygit, direnv, fzf, eza, neovim), `xdg.configFile` symlinks.
+- `nix/home/default.nix` — home-manager: `home.packages` (CLI/LSP/languages), `programs.*` declarative tool config (zsh, git, starship, delta, gh, bat, lazygit, direnv, fzf, eza, neovim), `xdg.configFile` symlinks.
 - `nix/modules/shared.nix` — `nix` daemon settings, `nixpkgs.config.allowUnfree`, `system.stateVersion`.
 - `hosts/<name>/default.nix` — `networking.hostName`, `networking.computerName`, host-specific `homebrew.masApps`.
-- `lib/mkdarwin.nix` — assembles all of the above; also packages `gh-branch` (shell script from flake input) and `gh-ghq-cd` (flake input's own package) since they aren't in nixpkgs.
+- `lib/mkdarwin.nix` — assembles all of the above; also packages `gh-branch` (shell script from flake input), `gh-ghq-cd`, and `herdr` (flake inputs' own packages) since they aren't in nixpkgs.
 
 ### Package management split
 
@@ -52,7 +52,7 @@ When adding a new host, create `hosts/<name>/default.nix` and add a `mkDarwin` e
 | `home.packages` (`nix/home`) | CLI tools, language toolchains, LSP servers |
 | `homebrew.casks` (`nix/darwin`) | GUI apps, fonts |
 | `homebrew.masApps` (`hosts/<name>`) | Personal Mac App Store apps — host-specific |
-| `programs.*` (`nix/home`) | Declarative config for zsh/git/tmux/starship/etc. |
+| `programs.*` (`nix/home`) | Declarative config for zsh/git/starship/etc. |
 | `xdg.configFile` (`nix/home`) | Symlinks from `config/<tool>/` to `~/.config/<tool>/` |
 
 ### Config symlink strategy
@@ -69,12 +69,15 @@ The helper must NOT gate on `builtins.pathExists` (or otherwise read the checkou
 
 `config/nvim/` is a full LazyVim setup managed by lazy.nvim — Nix only installs the `neovim` binary and LSP servers; plugins are managed inside Neovim. Ghostty and gh-dash used to live in `config/` as raw files but are now configured declaratively via `programs.ghostty.settings` / `programs.gh-dash.settings` so the akari module can layer its theme settings on top.
 
+`config/herdr/config.toml` is linked as a single file (not the whole `herdr/` directory) because herdr writes logs and session state into `~/.config/herdr/`. herdr rewrites the config in place (no atomic rename), so the out-of-store symlink survives writes from its onboarding flow / settings UI and those edits land in the repo file.
+
 ### Theme
 
-Akari Night is applied centrally via the [`cappyzawa/akari-theme`](https://github.com/cappyzawa/akari-theme) home-manager module. The flake input `akari-theme` is composed into the home configuration in `lib/mkdarwin.nix`, and `nix/home/default.nix` enables it with `akari = { enable = true; variant = "night"; };`. The module owns the theme for `bat`, `delta`, `fzf`, `gh-dash`, `ghostty`, `lazygit`, `starship`, `tmux`, and `zsh-syntax-highlighting`, so per-tool blocks in `nix/home/default.nix` must **not** redefine palettes or theme colours — doing so will collide with the module's settings.
+Akari Night is applied centrally via the [`cappyzawa/akari-theme`](https://github.com/cappyzawa/akari-theme) home-manager module. The flake input `akari-theme` is composed into the home configuration in `lib/mkdarwin.nix`, and `nix/home/default.nix` enables it with `akari = { enable = true; variant = "night"; };`. The module owns the theme for `bat`, `delta`, `fzf`, `gh-dash`, `ghostty`, `lazygit`, `starship`, and `zsh-syntax-highlighting`, so per-tool blocks in `nix/home/default.nix` must **not** redefine palettes or theme colours — doing so will collide with the module's settings.
 
 Out of scope for the module (managed differently or not managed):
 
+- **herdr** is not supported by the module. Its Akari Night palette is hand-written in `config/herdr/config.toml` (`[theme] name = "terminal"` follows Ghostty's akari ANSI palette; `[theme.custom]` overrides UI tokens with values taken from the upstream `dist/` generated themes). This block is the reference implementation for a future herdr template PR to `cappyzawa/akari-theme`.
 - **Neovim** uses the `cappyzawa/akari-nvim` plugin loaded by lazy.nvim in `config/nvim/lua/plugins/ui.lua`.
 - **Helix / Zellij / Alacritty** are unused in this setup.
 - **VSCode / macOS Terminal / Slack / Chrome** are intentionally not centralised — install/import their Akari themes manually from the upstream repo if desired.
@@ -86,12 +89,14 @@ To bump to a newer Akari release: `nix flake update akari-theme` then `make swit
 - `~/.gitconfig.local` — `[user] name = ... / email = ...`. Included by `programs.git.includes`; activation works without it but commits will be unattributed.
 - `~/.zshrc.local` — sourced at the end of zsh init for machine-specific overrides.
 
-## Tmux
+## Herdr (terminal multiplexer, replaced tmux)
 
+- Installed from the `herdr` flake input (`github:ogulcancelik/herdr`, Rust source build); config lives in `config/herdr/config.toml`
 - Prefix: `Ctrl-k` (not the default `Ctrl-b`)
-- Vim-style pane nav: `h/j/k/l`; splits: `|` (horizontal), `-` (vertical)
-- Window cycle: `Ctrl-]` / `Ctrl-[`
-- Auto-starts from zsh on terminal launch, except inside VS Code or an existing tmux session
+- Vim-style pane nav: prefix + `h/j/k/l` (herdr default); splits: prefix + `|` (side-by-side), prefix + `-` (stacked)
+- Tab cycle: prefix + `n`/`p` (herdr default) or prefix + `Ctrl-]`/`Ctrl-[` (tmux-era)
+- Auto-starts from zsh on terminal launch, except inside VS Code or an existing herdr pane (guarded by `HERDR_ENV`)
+- Sessions persist via herdr's background server (replaces tmux-resurrect/continuum); detach with prefix + `q`
 
 ## CI
 

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -1,0 +1,42 @@
+onboarding = false
+
+[update]
+# herdr is Nix-managed; its own version checks are noise.
+version_check = false
+
+[keys]
+prefix = "ctrl+k"
+# Keep the tmux-era split keys: `|` for side-by-side, `-` for stacked
+# (herdr's split_vertical = left/right, split_horizontal = top/bottom).
+split_vertical = "prefix+|"
+split_horizontal = "prefix+minus"
+# tmux-era C-] / C-[ tab cycling alongside herdr's default n/p.
+# prefix+ctrl+[ may collide with ESC in some terminals; prefix+p still works.
+next_tab = ["prefix+n", "prefix+ctrl+]"]
+previous_tab = ["prefix+p", "prefix+ctrl+["]
+
+[theme]
+# Base follows the host terminal's ANSI palette (Ghostty is themed by akari),
+# with UI tokens overridden below to Akari Night.
+name = "terminal"
+
+# Akari Night — taken from cappyzawa/akari-theme generated themes
+# (dist/ghostty/akari-night, dist/fzf/akari-night.sh, dist/lazygit/akari-night.yml).
+# Reference implementation for a future herdr template PR to akari-theme.
+[theme.custom]
+accent = "#E26A3B"      # lantern mid (akari primary accent)
+panel_bg = "#1E1C19"    # ANSI black0
+surface_dim = "#1E1C19"
+surface0 = "#412E23"    # inactive selection bg
+surface1 = "#51422E"    # selection bg
+overlay0 = "#3F4346"    # border
+overlay1 = "#716A5F"    # bright black
+text = "#E6DED3"        # foreground
+subtext0 = "#9BABB9"    # header/info
+red = "#D25046"
+green = "#7FAF6A"
+yellow = "#D4A05A"
+blue = "#7A8FA2"
+mauve = "#8E7BA0"
+teal = "#6F8F8A"
+peach = "#E26A3B"

--- a/config/zsh/10_utils.zsh
+++ b/config/zsh/10_utils.zsh
@@ -18,16 +18,6 @@ is_screen_running() {
     [[ -n $STY ]]
 }
 
-# is_tmux_runnning returns true if tmux is running
-is_tmux_runnning() {
-    [[ -n $TMUX ]]
-}
-
-# is_screen_or_tmux_running returns true if GNU screen or tmux is running
-is_screen_or_tmux_running() {
-    is_screen_running || is_tmux_runnning
-}
-
 # shell_has_started_interactively returns true if the current shell is
 # running from command line
 shell_has_started_interactively() {

--- a/flake.lock
+++ b/flake.lock
@@ -99,6 +99,26 @@
         "type": "github"
       }
     },
+    "herdr": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783211147,
+        "narHash": "sha256-7A8HDsDayPcW4qGV+Hjv6dqdjmEtXfTY4Lon8CFC4+E=",
+        "owner": "ogulcancelik",
+        "repo": "herdr",
+        "rev": "2bc1724c2dae72184a5d2ec070e30c70dc519f9b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ogulcancelik",
+        "repo": "herdr",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -182,10 +202,10 @@
         "akari-theme": "akari-theme",
         "gh-branch": "gh-branch",
         "gh-ghq-cd": "gh-ghq-cd",
+        "herdr": "herdr",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs",
-        "tpm": "tpm"
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-analyzer-src": {
@@ -217,22 +237,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "tpm": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1779036064,
-        "narHash": "sha256-oRKUZNyJYQXlkeQfbEYiltUEBpvdwn2SoEBWHVUNmrA=",
-        "owner": "tmux-plugins",
-        "repo": "tpm",
-        "rev": "e261deb1b47614eed3400089ce7197dc68acc4eb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tmux-plugins",
-        "repo": "tpm",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,11 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    tpm = {
-      url = "github:tmux-plugins/tpm";
-      flake = false;
+    # herdr — agent-aware terminal multiplexer (tmux replacement).
+    # Ships its own flake exposing packages.<system>.herdr.
+    herdr = {
+      url = "github:ogulcancelik/herdr";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # gh extensions (not in nixpkgs) — packaged via flake inputs.
@@ -40,7 +42,6 @@
       nixpkgs,
       nix-darwin,
       home-manager,
-      tpm,
       ...
     }@inputs:
     let

--- a/lib/mkdarwin.nix
+++ b/lib/mkdarwin.nix
@@ -14,7 +14,7 @@ name:
 }:
 
 let
-  inherit (inputs) nixpkgs nix-darwin home-manager tpm;
+  inherit (inputs) nixpkgs nix-darwin home-manager;
   pkgs = nixpkgs.legacyPackages.${system};
 
   # gh extensions that are not in nixpkgs, packaged from flake inputs.
@@ -32,6 +32,9 @@ let
 
   # gh-ghq-cd ships its own flake exposing a `gh-ghq-cd` package.
   gh-ghq-cd-pkg = inputs.gh-ghq-cd.packages.${system}.gh-ghq-cd;
+
+  # herdr ships its own flake exposing a `herdr` package (Rust source build).
+  herdr-pkg = inputs.herdr.packages.${system}.herdr;
 
   # ccstatusline — Claude Code status line formatter, fetched from npm registry.
   # The npm tarball ships a pre-built Bun bundle at dist/ccstatusline.js.
@@ -59,7 +62,7 @@ let
   };
 
   specialArgs = {
-    inherit inputs tpm;
+    inherit inputs;
     configName = name;
     currentUser = user;
     username = user; # backward compatibility
@@ -80,7 +83,7 @@ nix-darwin.lib.darwinSystem {
         useUserPackages = true;
         backupFileExtension = "backup";
         extraSpecialArgs = specialArgs // {
-          inherit gh-branch-pkg gh-ghq-cd-pkg ccstatusline-pkg;
+          inherit gh-branch-pkg gh-ghq-cd-pkg ccstatusline-pkg herdr-pkg;
         };
         users.${user} = {
           imports = [

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -3,11 +3,11 @@
   lib,
   config,
   username,
-  tpm,
   dotfilesRoot,
   gh-branch-pkg,
   gh-ghq-cd-pkg,
   ccstatusline-pkg,
+  herdr-pkg,
   ...
 }:
 let
@@ -110,6 +110,9 @@ in
 
       # Claude Code
       ccstatusline-pkg
+
+      # Terminal multiplexer (tmux replacement)
+      herdr-pkg
     ];
 
     # Session variables
@@ -142,7 +145,9 @@ in
 
   # Akari theme — centralised theme/palette management via the upstream
   # home-manager module (cappyzawa/akari-theme). Covers bat, delta, fzf,
-  # gh-dash, ghostty, lazygit, starship, tmux, and zsh-syntax-highlighting.
+  # gh-dash, ghostty, lazygit, starship, and zsh-syntax-highlighting.
+  # herdr is NOT covered by the module — its akari-night palette is
+  # hand-written in config/herdr/config.toml (candidate for an upstream PR).
   akari = {
     enable = true;
     variant = "night";
@@ -158,10 +163,11 @@ in
     "zsh/30_aliases.zsh".source = mutableConfigSource "zsh/30_aliases.zsh";
     "zsh/50_setopt.zsh".source = mutableConfigSource "zsh/50_setopt.zsh";
     "zsh/80_custom.zsh".source = mutableConfigSource "zsh/80_custom.zsh";
-    "tmux/plugins/tpm" = {
-      source = tpm;
-      recursive = true;
-    };
+    # herdr writes logs and session state into ~/.config/herdr/, so only the
+    # config file is linked — never the whole directory. herdr rewrites the
+    # file in place (no rename), so the out-of-store symlink survives writes
+    # from its onboarding flow / settings UI.
+    "herdr/config.toml".source = mutableConfigSource "herdr/config.toml";
   };
 
   # Programs configuration
@@ -240,9 +246,9 @@ in
             eval "$(mise activate zsh)"
           fi
 
-          # Auto start tmux
-          if command -v tmux &> /dev/null && [ -z "$TMUX" ] && [[ $TERM_PROGRAM != "vscode" ]]; then
-            exec tmux
+          # Auto start herdr (HERDR_ENV=1 is set inside herdr panes)
+          if command -v herdr &> /dev/null && [ -z "$HERDR_ENV" ] && [[ $TERM_PROGRAM != "vscode" ]]; then
+            exec herdr
           fi
         '')
       ];
@@ -302,105 +308,6 @@ in
         navigate = true;
         side-by-side = true;
       };
-    };
-
-    # Tmux
-    tmux = {
-      enable = true;
-      prefix = "C-k";
-      shell = "${pkgs.zsh}/bin/zsh";
-      terminal = "screen-256color";
-      mouse = true;
-      baseIndex = 1;
-      escapeTime = 50;
-      keyMode = "vi";
-      historyLimit = 50000;
-
-      extraConfig = ''
-        # Default command for macOS
-        set-option -g default-command "exec arch -arch arm64 /bin/zsh --login"
-        set-option -g focus-events on
-        set-option -ga terminal-overrides ",xterm-256color:Tc"
-
-        # Split window from current path
-        bind-key | split-window -h -c '#{pane_current_path}'
-        unbind '"'
-        bind-key - split-window -v -c '#{pane_current_path}'
-        unbind '%'
-
-        # New Window
-        bind-key c new-window -c '#{pane_current_path}'
-
-        # Equal layouts
-        bind ^h select-layout even-horizontal
-        bind ^v select-layout even-vertical
-
-        # Move window in order
-        bind-key C-] select-window -t +1
-        bind-key C-[ select-window -t -1
-
-        # Custom mouse settings
-        unbind-key -T root MouseDown1Pane
-        unbind-key -T root MouseDown3Pane
-
-        # Pane Title
-        bind-key C-k run 'zsh -c "arr=( top off ) && tmux setw pane-border-status \''${arr[\$(( \''${arr[(I)#{pane-border-status}]} % 2 + 1 ))]}"'
-        bind-key : command-prompt -p "(rename-pane)" "select-pane -T %%"
-
-        # Resize pane
-        bind-key -r H resize-pane -L 5
-        bind-key -r J resize-pane -D 5
-        bind-key -r K resize-pane -U 5
-        bind-key -r L resize-pane -R 5
-
-        # Change active pane
-        bind-key h select-pane -L
-        bind-key j select-pane -D
-        bind-key k select-pane -U
-        bind-key l select-pane -R
-
-        # Reload config file
-        bind-key r source-file ~/.config/tmux/tmux.conf\; display-message "[tmux] tmux.conf reloaded!"
-
-        # sync
-        bind a setw synchronize-panes \; display "synchronize-panes #{?pane_synchronized,on,off}"
-
-        # Look up in a man-page
-        bind-key m command-prompt -p "Man:" "split-window 'man %%'"
-
-        # status bar
-        set-option -g status-position top
-        set -g status-keys vi
-
-        # Copy mode like vim
-        bind-key v copy-mode \; display "Copy mode!"
-        bind-key p paste-buffer
-        bind-key -T edit-mode-vi Up send-keys -X history-up
-        bind-key -T edit-mode-vi Down send-keys -X history-down
-        unbind-key -T copy-mode-vi Space
-        bind-key -T copy-mode-vi v send-keys -X begin-selection
-        bind-key -T copy-mode-vi V send-keys -X select-line
-        bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
-        bind-key -T copy-mode-vi c send-keys -X clear-selection
-        bind-key -T copy-mode-vi H send-keys -X start-of-line
-        bind-key -T copy-mode-vi L send-keys -X end-of-line
-        bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "pbcopy"
-        bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
-        bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
-
-        set-environment -g PATH "/opt/homebrew/bin:/usr/local/bin:/bin:/usr/bin:$PATH"
-        TMUX_FZF_SED="/usr/local/opt/gnu-sed/libexec/gnubin/sed"
-
-        # List of plugins
-        set -g @plugin 'tmux-plugins/tpm'
-        set -g @plugin 'tmux-plugins/tmux-open'
-        set -g @plugin 'sainnhe/tmux-fzf'
-        set -g @plugin 'tmux-plugins/tmux-resurrect'
-        set -g @plugin 'tmux-plugins/tmux-continuum'
-
-        # Initialize TMUX plugin manager
-        run -b '~/.config/tmux/plugins/tpm/tpm'
-      '';
     };
 
     # Starship prompt


### PR DESCRIPTION
## Summary

tmux を [herdr](https://herdr.dev/)(`github:ogulcancelik/herdr`、エージェント対応のRust製ターミナルマルチプレクサ)に完全移行する。

- **導入**: herdr を flake input として追加(`gh-ghq-cd` と同パターン、Renovate が自動更新)。`lib/mkdarwin.nix` で `packages.<system>.herdr` を `herdr-pkg` として home-manager に渡し、`home.packages` へ。
- **削除**: `programs.tmux` ブロック、`tpm` flake input と TPM symlink、tmux 自動起動、`config/zsh/10_utils.zsh` の死んだ tmux ヘルパー。
- **自動起動**: zsh の auto-start を herdr に置換。ネストガードは `$TMUX` → `$HERDR_ENV`(herdr が全ペインに `HERDR_ENV=1` を設定 — `src/pty/backend/unix.rs:77` で確認)。
- **設定** (`config/herdr/config.toml`、新規):
  - `mutableConfigSource` で **ファイル単体** symlink(herdr は `~/.config/herdr/` にログ・session.json も書くためディレクトリごとは不可)。herdr の config 書き込みは in-place(`std::fs::write`)なので out-of-store symlink と両立。
  - prefix `ctrl+k`、tmux 時代の `|`(左右)/ `-`(上下)split、`C-]`/`C-[` タブ巡回(+ herdr デフォルトの `n`/`p`)。pane 移動 `h/j/k/l`・新タブ `c`・copy mode `[`・detach `q` は herdr デフォルトが tmux 設定とほぼ一致するため上書き不要。
- **テーマ**: akari-theme モジュールは herdr 未対応のため、`[theme] name = "terminal"`(Ghostty の akari ANSI パレットに追従)+ `[theme.custom]` に Akari Night の UI トークンを手書き。色は上流の生成済みテーマ(`dist/ghostty`・`dist/fzf`・`dist/lazygit` の akari-night)から採取。将来 `cappyzawa/akari-theme` への herdr テンプレート PR の参照実装を兼ねる。

### 意図的に落とした機能

- tmux-resurrect / continuum → herdr ビルトインの永続化(バックグラウンドサーバ + session restore)で代替
- tmux-open / tmux-fzf → 廃止(herdr はマウスネイティブ + sidebar)
- synchronize-panes・man split 等の細かいバインド → 必要になったら `[[keys.command]]` で追加可能

## Verification

- `nix flake check` — passed
- `nix build .#darwinConfigurations.sh05MacminiM2.system` — herdr 0.7.1 のソースビルド(zig の libghostty-vt + cargo)含めフルビルド成功、`herdr --version` 動作確認済み
- `config.toml` は TOML 構文チェック済み、キー/テーマのフィールド名は herdr ソース(`src/config/keybinds.rs`, `src/config/theme.rs`)と照合済み

### マージ後の確認手順

1. `make switch`(初回は herdr のソースビルドで時間がかかる。flake.lock 更新済みなので同一リビジョンならビルド済みキャッシュが効く)
2. 新しいターミナルで herdr が自動起動すること
3. `ctrl+k |` / `ctrl+k -` で split、`ctrl+k h/j/k/l` で pane 移動、`ctrl+k c` でタブ作成
4. `ctrl+k ctrl+[` が効かない場合(ESC と衝突する可能性あり)は `prefix+p` を使うか config から削る
5. テーマの見た目を確認し、`[theme.custom]` を好みに微調整

## 適用方法

```bash
git checkout main && git pull
git merge feat/migrate-tmux-to-herdr   # または PR をマージ
make switch                            # NIXNAME は ~/.config/nix/host から自動読み込み
```

## 有事の際のロールバック(herdr → tmux)

状況に応じて2通り。

### A. すぐ前の generation に戻すだけ(このPR以外の変更も一緒に巻き戻る)

```bash
make rollback                # sudo darwin-rebuild switch --rollback
# 特定世代を指定したい場合:
make list-generations
make switch-generation GEN=<N>
```

nix-darwin の generation を1つ戻すだけなので、tmux の設定・パッケージ・自動起動が即座に復元される。**このPR以降に他の変更を switch していると、それも一緒に巻き戻る点に注意。**

### B. このPRだけを取り消して tmux に戻す(他の変更は残す)

```bash
git checkout main
git revert -m 1 <このPRのマージコミットSHA>   # squash merge の場合は単に git revert <コミットSHA>
make switch
```

`programs.tmux` ブロック・TPM symlink・tmux 自動起動・`config/zsh/10_utils.zsh` のヘルパーがすべて復元され、`herdr` input と `config/herdr/config.toml` が削除される。以後の変更を残したまま tmux 運用に戻せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
