### PR TITLE
fix(nix): add /opt/homebrew/{bin,sbin} to sessionPath

### DIFF
--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -223,6 +223,13 @@ in
       "$HOME/.cargo/bin"
       "$HOME/.rd/bin"
       "$HOME/.lmstudio/bin"
+      # homebrew: nix 移行で ~/.zprofile の `brew shellenv` が home-manager
+      # 管理に置き換わって消え、brew と brew 製 CLI が PATH から落ちていた。
+      # sessionPath は $PATH の前に挿入されるため並びは brew shellenv 時代と
+      # 同じ (brew が nix profile より先)。同名ツールを brew で入れると
+      # nix 側が隠れる点だけ注意
+      "/opt/homebrew/bin"
+      "/opt/homebrew/sbin"
     ];
 
     # Plain dotfiles in $HOME (tool configs that don't live under ~/.config)


### PR DESCRIPTION
The nix migration replaced ~/.zprofile (where 'brew shellenv' used to live) with a home-manager symlink, silently dropping brew and all brew-installed CLIs from PATH. Declare homebrew paths in sessionPath; ordering matches the old shellenv setup (brew before nix profiles).